### PR TITLE
add support for TLS client certificate

### DIFF
--- a/cmd/kaf/kaf.go
+++ b/cmd/kaf/kaf.go
@@ -35,13 +35,12 @@ func getConfig() (saramaConfig *sarama.Config) {
 			InsecureSkipVerify: cluster.TLS.Insecure,
 		}
 
-		caCert, err := ioutil.ReadFile(cluster.TLS.Cafile)
-		if err != nil {
-			errorExit("Unable to read Cafile :%v\n", err)
+		caCert, _ := ioutil.ReadFile(cluster.TLS.Cafile)
+		if caCert != nil {
+			caCertPool := x509.NewCertPool()
+			caCertPool.AppendCertsFromPEM(caCert)
+			tlsConfig.RootCAs = caCertPool
 		}
-		caCertPool := x509.NewCertPool()
-		caCertPool.AppendCertsFromPEM(caCert)
-		tlsConfig.RootCAs = caCertPool
 
 		clientCert, err := ioutil.ReadFile(cluster.TLS.Clientfile)
 		if err != nil {

--- a/cmd/kaf/kaf.go
+++ b/cmd/kaf/kaf.go
@@ -35,8 +35,11 @@ func getConfig() (saramaConfig *sarama.Config) {
 			InsecureSkipVerify: cluster.TLS.Insecure,
 		}
 
-		caCert, _ := ioutil.ReadFile(cluster.TLS.Cafile)
-		if caCert != nil {
+		if cluster.TLS.Cafile != "" {
+			caCert, err := ioutil.ReadFile(cluster.TLS.Cafile)
+			if err != nil {
+				errorExit("Unable to read Cafile :%v\n", err)
+			}
 			caCertPool := x509.NewCertPool()
 			caCertPool.AppendCertsFromPEM(caCert)
 			tlsConfig.RootCAs = caCertPool

--- a/cmd/kaf/kaf.go
+++ b/cmd/kaf/kaf.go
@@ -37,8 +37,7 @@ func getConfig() (saramaConfig *sarama.Config) {
 
 		caCert, err := ioutil.ReadFile(cluster.TLS.Cafile)
 		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
+			errorExit("Unable to read Cafile :%v\n", err)
 		}
 		caCertPool := x509.NewCertPool()
 		caCertPool.AppendCertsFromPEM(caCert)
@@ -46,18 +45,16 @@ func getConfig() (saramaConfig *sarama.Config) {
 
 		clientCert, err := ioutil.ReadFile(cluster.TLS.Clientfile)
 		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
+			errorExit("Unable to read Clientfile :%v\n", err)
 		}
 		clientKey, err := ioutil.ReadFile(cluster.TLS.Clientkeyfile)
 		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
+			errorExit("Unable to read Clientkeyfile :%v\n", err)
 		}
 
 		cert, err := tls.X509KeyPair([]byte(clientCert), []byte(clientKey))
 		if err != nil {
-			log.Fatal(err)
+			errorExit("Unable to creatre KeyPair: %v\n", err)
 		}
 		tlsConfig.Certificates = []tls.Certificate{cert}
 

--- a/config.go
+++ b/config.go
@@ -16,8 +16,10 @@ type SASL struct {
 }
 
 type TLS struct {
-	Cafile   string
-	Insecure bool
+	Cafile        string
+	Clientfile    string
+	Clientkeyfile string
+	Insecure      bool
 }
 
 type Cluster struct {


### PR DESCRIPTION
This PR enables a user to establish a secure client connection to the Kafka cluster using a TLS certificate and private key.