### PR TITLE
Show sums for groups and topics

### DIFF
--- a/cmd/kaf/group.go
+++ b/cmd/kaf/group.go
@@ -323,10 +323,17 @@ var groupDescribeCmd = &cobra.Command{
 
 			wms := getHighWatermarks(topic, p)
 
+			lagSum := 0
+			offsetSum := 0
 			for _, partition := range p {
+				lag := (wms[partition] - partitions[partition].Offset)
+				lagSum += int(lag)
+				offset := partitions[partition].Offset
+				offsetSum += int(offset)
 				fmt.Fprintf(w, "\t\t%v\t%v\t%v\t%v\t%v\n", partition, partitions[partition].Offset, wms[partition], (wms[partition] - partitions[partition].Offset), partitions[partition].Metadata)
 			}
 
+			fmt.Fprintf(w, "\t\tTotal\t%d\t\t%d\t\n", offsetSum, lagSum)
 		}
 
 		fmt.Fprintf(w, "Members:\t")

--- a/cmd/kaf/topic.go
+++ b/cmd/kaf/topic.go
@@ -140,6 +140,7 @@ var describeTopicCmd = &cobra.Command{
 			partitions = append(partitions, partition.ID)
 		}
 		highWatermarks := getHighWatermarks(args[0], partitions)
+		highWatermarksSum := 0
 
 		for _, partition := range detail.Partitions {
 			sortedReplicas := partition.Replicas
@@ -148,8 +149,16 @@ var describeTopicCmd = &cobra.Command{
 			sortedISR := partition.Isr
 			sort.Slice(sortedISR, func(i, j int) bool { return sortedISR[i] < sortedISR[j] })
 
+			highWatermarksSum += int(highWatermarks[partition.ID])
+
 			fmt.Fprintf(w, "\t%v\t%v\t%v\t%v\t%v\t\n", partition.ID, highWatermarks[partition.ID], partition.Leader, sortedReplicas, sortedISR)
 		}
+
+		w.Flush()
+
+		fmt.Fprintf(w, "Summed HighWatermark:\t%d\n", highWatermarksSum)
+		w.Flush()
+
 		fmt.Fprintf(w, "Config:\n")
 		fmt.Fprintf(w, "\tName\tValue\tReadOnly\tSensitive\t\n")
 		fmt.Fprintf(w, "\t----\t-----\t--------\t---------\t\n")


### PR DESCRIPTION
This enhances `group describe` a line showing the summed offsets and lags for the group, and enhances `topic describe` with a line showing the summed high-watermark. This is useful when running kaf under `watch` or when you have a lot of partitions and slow producers/consumers and it's hard to tell if they're making progress.