### PR TITLE
Fix reading config error

### DIFF
--- a/cmd/kaf/kaf.go
+++ b/cmd/kaf/kaf.go
@@ -140,8 +140,8 @@ var setupProtoDescriptorRegistry = func(cmd *cobra.Command, args []string) {
 func onInit() {
 	var err error
 	config, err = kaf.ReadConfig()
-	if err != nil && !os.IsNotExist(err) {
-		errorExit("Config %s does not exist", config)
+	if err != nil {
+		errorExit("Invalid config: %v", err)
 	}
 
 	cluster := config.ActiveCluster()
@@ -198,6 +198,6 @@ func getSchemaCache() (cache *avro.SchemaCache) {
 }
 
 func errorExit(format string, a ...interface{}) {
-	fmt.Fprintf(os.Stderr, format, a...)
+	fmt.Fprintf(os.Stderr, format+"\n", a...)
 	os.Exit(1)
 }

--- a/config.go
+++ b/config.go
@@ -94,6 +94,9 @@ func (c *Config) Write() error {
 func ReadConfig() (c Config, err error) {
 	file, err := os.OpenFile(getDefaultConfigPath(), os.O_RDONLY, 0644)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return Config{}, nil
+		}
 		return Config{}, err
 	}
 	decoder := yaml.NewDecoder(file)


### PR DESCRIPTION
Small fix for reading config

before
```sh
$ mkdir ~/.kaf
$ echo 'invalid config' > ~/.kaf/config
$ kaf -b localhost:9092 topics
Config { []} does not exist $ # <-- no new line here
```
after
```sh
$ kaf -b localhost:9092 topics
Invalid config: yaml: unmarshal errors:
  line 1: cannot unmarshal !!str `invalid...` into kaf.Config
```