### PR TITLE
Allow Cluster Override on Command Line

### DIFF
--- a/cmd/kaf/kaf.go
+++ b/cmd/kaf/kaf.go
@@ -117,6 +117,7 @@ var (
 	protoFiles        []string
 	protoExclude      []string
 	verbose           bool
+	clusterOverride   string
 )
 
 func init() {
@@ -124,6 +125,7 @@ func init() {
 	rootCmd.PersistentFlags().StringSliceVarP(&brokersFlag, "brokers", "b", nil, "Comma separated list of broker ip:port pairs")
 	rootCmd.PersistentFlags().StringVar(&schemaRegistryURL, "schema-registry", "", "URL to a Confluent schema registry. Used for attempting to decode Avro-encoded messages")
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Whether to turn on sarama logging")
+	rootCmd.PersistentFlags().StringVarP(&clusterOverride, "cluster", "c", "", "set a temporary current cluster")
 	cobra.OnInitialize(onInit)
 }
 
@@ -143,6 +145,8 @@ func onInit() {
 	if err != nil {
 		errorExit("Invalid config: %v", err)
 	}
+
+	config.ClusterOverride = clusterOverride
 
 	cluster := config.ActiveCluster()
 	if cluster != nil {

--- a/config.go
+++ b/config.go
@@ -32,8 +32,9 @@ type Cluster struct {
 }
 
 type Config struct {
-	CurrentCluster string     `yaml:"current-cluster"`
-	Clusters       []*Cluster `yaml:"clusters"`
+	CurrentCluster  string `yaml:"current-cluster"`
+	ClusterOverride string
+	Clusters        []*Cluster `yaml:"clusters"`
 }
 
 func (c *Config) SetCurrentCluster(name string) error {
@@ -60,12 +61,21 @@ func (c *Config) SetCurrentCluster(name string) error {
 }
 
 func (c *Config) ActiveCluster() *Cluster {
-	if c == nil || c.CurrentCluster == "" {
+	if c == nil {
+		return nil
+	}
+
+	toSearch := c.ClusterOverride
+	if c.ClusterOverride == "" {
+		toSearch = c.CurrentCluster
+	}
+
+	if toSearch == "" {
 		return nil
 	}
 
 	for _, cluster := range c.Clusters {
-		if cluster.Name == c.CurrentCluster {
+		if cluster.Name == toSearch {
 			return cluster
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/golang/protobuf v1.3.1
 	github.com/hokaccha/go-prettyjson v0.0.0-20180920040306-f579f869bbfe
 	github.com/jcmturner/gofork v1.0.0 // indirect
-	github.com/jhump/protoreflect v1.4.4
+	github.com/jhump/protoreflect v1.5.0
 	github.com/linkedin/goavro v2.1.0+incompatible
 	github.com/magiconair/properties v1.8.1
 	github.com/manifoldco/promptui v0.3.2

--- a/go.sum
+++ b/go.sum
@@ -65,6 +65,8 @@ github.com/jcmturner/gofork v1.0.0 h1:J7uCkflzTEhUZ64xqKnkDxq3kzc96ajM1Gli5ktUem
 github.com/jcmturner/gofork v1.0.0/go.mod h1:MK8+TM0La+2rjBD4jE12Kj1pCCxK7d2LK/UM3ncEo0o=
 github.com/jhump/protoreflect v1.4.4 h1:kySdALZUh7xRtW6UoZjjHtlR8k7rLzx5EXJFRvsO5UY=
 github.com/jhump/protoreflect v1.4.4/go.mod h1:gZ3i/BeD62fjlaIL0VW4UDMT70CTX+3m4pOnAlJ0BX8=
+github.com/jhump/protoreflect v1.5.0 h1:NgpVT+dX71c8hZnxHof2M7QDK7QtohIJ7DYycjnkyfc=
+github.com/jhump/protoreflect v1.5.0/go.mod h1:eaTn3RZAmMBcV0fifFvlm6VHNz3wSkYyXYWUh7ymB74=
 github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a h1:FaWFmfWdAUKbSCtOU2QjDaorUexogfaMgbipgYATUMU=
 github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a/go.mod h1:UJSiEoRfvx3hP73CvoARgeLjaIOjybY9vj8PUPPFGeU=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
@@ -154,6 +156,8 @@ golang.org/x/tools v0.0.0-20181122213734-04b5d21e00f1 h1:bsEj/LXbv3BCtkp/rBj9Wi/
 golang.org/x/tools v0.0.0-20181122213734-04b5d21e00f1/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190712213246-8b927904ee0d h1:JZPFnINSinLUdC0BJDoKhrky8niIzXMPIY2oR07+I+E=
 golang.org/x/tools v0.0.0-20190712213246-8b927904ee0d/go.mod h1:jcCCGcm9btYwXyDqrUWc6MKQKKGJCWEQ3AfLSRIbEuI=
+google.golang.org/genproto v0.0.0-20170818010345-ee236bd376b0 h1:ZvI3lsq5AIkr7axxmT3tfwFlJVRFLqe6Fp0W03+MJ38=
+google.golang.org/genproto v0.0.0-20170818010345-ee236bd376b0/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20170818100345-ee236bd376b0 h1:jgaHBfsPDMBDKsth1hPtI1HcOyecWndWOFSGW21VgaM=
 google.golang.org/genproto v0.0.0-20170818100345-ee236bd376b0/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/grpc v1.8.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=


### PR DESCRIPTION
When working with multiple clusters sometimes it's useful to be able to temporarily use a different cluster without overwriting the current default one with `kaf config use-cluster`.  This introduces the `-c` and `--cluster` flags which allow the user to specify which cluster to use on the command line.  This mimics the way `kubectl` deals with "context" and `gcloud` deals with "project".

It also updates the `github.com/jhump/protoreflect` dependency so that we can build under go v1.13.  Otherwise you get:
```
go: github.com/jhump/protoreflect@v1.4.4 requires
	google.golang.org/genproto@v0.0.0-20170818100345-ee236bd376b0: invalid pseudo-version: does not match version-control timestamp (2017-08-18T01:03:45Z)
```

