### PR TITLE
Update topic.go so `topic create` works again.

### DIFF
--- a/cmd/kaf/topic.go
+++ b/cmd/kaf/topic.go
@@ -28,7 +28,7 @@ func init() {
 
 	createTopicCmd.Flags().Int32VarP(&partitionsFlag, "partitions", "p", int32(1), "Number of partitions")
 	createTopicCmd.Flags().Int16VarP(&replicasFlag, "replicas", "r", int16(1), "Number of replicas")
-	createTopicCmd.Flags().BoolVarP(&compactFlag, "compact", "c", false, "Enable topic compaction")
+	createTopicCmd.Flags().BoolVarP(&compactFlag, "compact", "C", false, "Enable topic compaction")
 
 	lsTopicsCmd.Flags().BoolVar(&noHeaderFlag, "no-headers", false, "Hide table headers")
 }

--- a/cmd/kaf/topic.go
+++ b/cmd/kaf/topic.go
@@ -28,7 +28,7 @@ func init() {
 
 	createTopicCmd.Flags().Int32VarP(&partitionsFlag, "partitions", "p", int32(1), "Number of partitions")
 	createTopicCmd.Flags().Int16VarP(&replicasFlag, "replicas", "r", int16(1), "Number of replicas")
-	createTopicCmd.Flags().BoolVarP(&compactFlag, "compact", "", false, "Enable topic compaction")
+	createTopicCmd.Flags().BoolVar(&compactFlag, "compact", false, "Enable topic compaction")
 
 	lsTopicsCmd.Flags().BoolVar(&noHeaderFlag, "no-headers", false, "Hide table headers")
 }

--- a/cmd/kaf/topic.go
+++ b/cmd/kaf/topic.go
@@ -28,7 +28,7 @@ func init() {
 
 	createTopicCmd.Flags().Int32VarP(&partitionsFlag, "partitions", "p", int32(1), "Number of partitions")
 	createTopicCmd.Flags().Int16VarP(&replicasFlag, "replicas", "r", int16(1), "Number of replicas")
-	createTopicCmd.Flags().BoolVarP(&compactFlag, "compact", "C", false, "Enable topic compaction")
+	createTopicCmd.Flags().BoolVarP(&compactFlag, "compact", "", false, "Enable topic compaction")
 
 	lsTopicsCmd.Flags().BoolVar(&noHeaderFlag, "no-headers", false, "Hide table headers")
 }


### PR DESCRIPTION
`kaf topic create test-topic` panics.

Create topic is currently **broken** because `-c` is already in use. Get error:
> panic: unable to redefine 'c' shorthand in "create" flagset: it's already used for "compact" flag

This will fix it to use `-C` as shorthand for `--compact` instead of `-c`.

`kaf topic create -C test-topic-compact`