### PR TITLE
Allow per-cluster conf of Kafka version passed to sarama

### DIFF
--- a/cmd/kaf/kaf.go
+++ b/cmd/kaf/kaf.go
@@ -25,6 +25,13 @@ func getConfig() (saramaConfig *sarama.Config) {
 	saramaConfig.Producer.Return.Successes = true
 
 	cluster := currentCluster
+	if cluster.Version != "" {
+		parsedVersion, err := sarama.ParseKafkaVersion(cluster.Version)
+		if err != nil {
+			errorExit("Unable to parse Kafka version: %v\n", err)
+		}
+		saramaConfig.Version = parsedVersion
+	}
 	if cluster.SASL != nil {
 		saramaConfig.Net.SASL.Enable = true
 		saramaConfig.Net.SASL.User = cluster.SASL.Username

--- a/config.go
+++ b/config.go
@@ -24,6 +24,7 @@ type TLS struct {
 
 type Cluster struct {
 	Name              string
+	Version           string   `yaml:"version"`
 	Brokers           []string `yaml:"brokers"`
 	SASL              *SASL    `yaml:"SASL"`
 	TLS               *TLS     `yaml:"TLS"`


### PR DESCRIPTION
This PR adds support for customizing the Kafka version passed to sarama on a per-cluster basis.

This PR also bumps the default version down to `0.10.0.0`, in an attempt to provide wider support by default. Is this a change you would like to make? Or would you perhaps rather keep the default version at `1.1.0.0` and print an error message describing how to change the configured version?

(I also see the `go.mod` and `go.sum` files changed. I'm not familiar enough with building for Go to understand whether those changes are semantically significant, or undesired.)