### PR TITLE
Report error when partition has no leader

### DIFF
--- a/cmd/kaf/group.go
+++ b/cmd/kaf/group.go
@@ -339,7 +339,10 @@ func getHighWatermarks(topic string, partitions []int32) (watermarks map[int32]i
 	leaders := make(map[*sarama.Broker][]int32)
 
 	for _, partition := range partitions {
-		leader, _ := client.Leader(topic, partition)
+		leader, err := client.Leader(topic, partition)
+		if err != nil {
+			errorExit("Unable to get available offsets for partition without leader. Topic %s Partition %d, Error: %s ", topic, partition, err)
+		}
 		leaders[leader] = append(leaders[leader], partition)
 	}
 	wg := sync.WaitGroup{}


### PR DESCRIPTION
If a partition does not have a leader, kaf is failing at topic describe.
This should catch the similar situation in getHighmarks and at least propagate the error out.

Current output:
```
% kaf topic describe partitionless-topic-name
Name:        partitionless-topic-name
Internal:    false
Compacted:   false
Partitions:
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x50 pc=0x4397408]

goroutine 6 [running]:
github.com/birdayz/kaf/vendor/github.com/Shopify/sarama.(*Broker).send(0x0, 0x4a3a080, 0xc0002eca60, 0xc0001d0301, 0x0, 0x0, 0x0)
	/Users/mkunc/go/src/github.com/birdayz/kaf/vendor/github.com/Shopify/sarama/broker.go:663 +0x68
github.com/birdayz/kaf/vendor/github.com/Shopify/sarama.(*Broker).sendAndReceive(0x0, 0x4a3a080, 0xc0002eca60, 0x4a29620, 0xc0001d03c0, 0x0, 0x0)
	/Users/mkunc/go/src/github.com/birdayz/kaf/vendor/github.com/Shopify/sarama/broker.go:709 +0x72
github.com/birdayz/kaf/vendor/github.com/Shopify/sarama.(*Broker).GetAvailableOffsets(0x0, 0xc0002eca60, 0x0, 0x0, 0x0)
	/Users/mkunc/go/src/github.com/birdayz/kaf/vendor/github.com/Shopify/sarama/broker.go:327 +0x70
main.getHighWatermarks.func1(0x7ffeefbff8a3, 0x28, 0xc000111200, 0xc0002e0cf0, 0x0, 0xc0002eca60)
	/Users/mkunc/go/src/github.com/birdayz/kaf/cmd/kaf/group.go:361 +0x4d
created by main.getHighWatermarks
	/Users/mkunc/go/src/github.com/birdayz/kaf/cmd/kaf/group.go:360 +0x4b1
```