### PR TITLE
typo in kafka topic describe example

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ List topics, partitions and replicas
 
 Describe a given topic called _mqtt.messages.incoming_
 
-`kaf topics describe mqtt.messages.incoming`
+`kaf topic describe mqtt.messages.incoming`
 
 List consumer groups
 


### PR DESCRIPTION
Hi, 
I suggest a small improvement in README.

Thanks. 