### PR TITLE
Only allow group commit on empty consumergroups

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ Write message into given topic from stdin
 
 `echo test | kaf produce mqtt.messages.incoming`
 
+Set offset for consumer group _dispatcher_ consuming from topic _mqtt.messages.incoming_ to latest for all partitions
+
+`kaf group commit dispatcher -t mqtt.messages.incoming --offset latest --all-partitions`
+
 ## Configuration
 See the [examples](examples) folder
 

--- a/cmd/kaf/main_test.go
+++ b/cmd/kaf/main_test.go
@@ -21,8 +21,10 @@ func TestMain(m *testing.M) {
 }
 
 func testMain(m *testing.M) (code int) {
-	p := kafka.Preset(kafka.WithTopics("kaf-testing", "gnomock-kafka"))
-	c, err := gnomock.Start(p)
+	c, err := gnomock.Start(
+		kafka.Preset(kafka.WithTopics("kaf-testing", "gnomock-kafka")),
+		gnomock.WithContainerName("kaf-kafka"),
+	)
 	if err != nil {
 		return 1
 	}


### PR DESCRIPTION
Adds a simple check to the `kaf group commit` cmd that exits if the consumer group is active. In local testing it was possible for me to set the offset for an active consumer 😬 , thus the change.

Also added a small example in the readme so its more explicit

I've been having problems running the tests locally so no tests atm, if anyone has any advice, please share! 🙇 Would be happy to add some test coverage in a follow up MR 