### PR TITLE
Add version flag to show the current version of the tool

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -23,7 +23,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Build
-      run: go build -v ./cmd/kaf
+      run: go build -v -ldflags "-s -w -X main.version=$GITHUB_REF -X main.commit=${GITHUB_SHA::8}" ./cmd/kaf
 
     - name: Test
       run: go test -v ./...

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ yay -S kaf
 
 ## Usage
 
+Show the tool version
+
+`kaf --version`
+
 Add a local Kafka with no auth
 
 `kaf config add-cluster local -b localhost:9092`

--- a/cmd/kaf/kaf.go
+++ b/cmd/kaf/kaf.go
@@ -123,9 +123,15 @@ var (
 	colorableOut io.Writer = colorable.NewColorableStdout()
 )
 
+// Will be replaced by GitHub action and by goreleaser
+// see https://goreleaser.com/customization/build/
+var commit string = "HEAD"
+var version string = "latest"
+
 var rootCmd = &cobra.Command{
-	Use:   "kaf",
-	Short: "Kafka Command Line utility for cluster management",
+	Use:     "kaf",
+	Short:   "Kafka Command Line utility for cluster management",
+	Version: fmt.Sprintf("%s (%s)", version, commit),
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		outWriter = cmd.OutOrStdout()
 		errWriter = cmd.ErrOrStderr()


### PR DESCRIPTION
Hi @birdayz 

I finally decided to try a first contribution for this project that has been so useful in the last year of my work.
I'm no go expert but I hope this is a good contribution and a good start.

As requested in #158 this PR:
- sets the `version` on Cobra root command as [per documentation](https://github.com/spf13/cobra/blob/master/user_guide.md#version-flag)
- The version and commit values will be replaced automatically at build time by GitHub action and [goreleaser using `ldflags`](https://goreleaser.com/customization/build/)

Output:
```
$> go build -v -ldflags "-s -w -X main.version=v2.0 -X main.commit=abc" ./cmd/kaf/
$> ./kaf --version
kaf version v2.0 (abc)
```