### PR TITLE
support selection for current cluster && ls alias

### DIFF
--- a/cmd/kaf/config.go
+++ b/cmd/kaf/config.go
@@ -25,7 +25,6 @@ func init() {
 	configCmd.AddCommand(configAddClusterCmd)
 	configCmd.AddCommand(configRemoveClusterCmd)
 	configCmd.AddCommand(configSelectCluster)
-	rootCmd.AddCommand(lsCommand)
 	configCmd.AddCommand(configCurrentContext)
 	configCmd.AddCommand(configAddEventhub)
 	rootCmd.AddCommand(configCmd)
@@ -117,52 +116,45 @@ var configAddEventhub = &cobra.Command{
 	},
 }
 
-var configSelectClusterRunFunc = func(cmd *cobra.Command, args []string) {
-	var clusterNames []string
-	var pos = 0
-	for k, cluster := range cfg.Clusters {
-		clusterNames = append(clusterNames, cluster.Name)
-		if cluster.Name == cfg.CurrentCluster {
-			pos = k
-		}
-	}
-
-	searcher := func(input string, index int) bool {
-		cluster := clusterNames[index]
-		name := strings.Replace(strings.ToLower(cluster), " ", "", -1)
-		input = strings.Replace(strings.ToLower(input), " ", "", -1)
-		return strings.Contains(name, input)
-	}
-
-	p := promptui.Select{
-		Label:     "Select cluster",
-		Items:     clusterNames,
-		Searcher:  searcher,
-		Size:      10,
-		CursorPos: pos,
-	}
-
-	_, selected, err := p.Run()
-	if err != nil {
-		os.Exit(0)
-	}
-
-	// TODO copy pasta
-	if err := cfg.SetCurrentCluster(selected); err != nil {
-		fmt.Printf("Cluster with selected %v not found\n", selected)
-	}
-}
-
 var configSelectCluster = &cobra.Command{
-	Use:   "select-cluster",
-	Short: "Interactively select a cluster",
-	Run:   configSelectClusterRunFunc,
-}
+	Use:     "select-cluster",
+	Aliases: []string{"ls"},
+	Short:   "Interactively select a cluster",
+	Run: func(cmd *cobra.Command, args []string) {
+		var clusterNames []string
+		var pos = 0
+		for k, cluster := range cfg.Clusters {
+			clusterNames = append(clusterNames, cluster.Name)
+			if cluster.Name == cfg.CurrentCluster {
+				pos = k
+			}
+		}
 
-var lsCommand = &cobra.Command{
-	Use:   "ls",
-	Short: "Interactively select a cluster",
-	Run:   configSelectClusterRunFunc,
+		searcher := func(input string, index int) bool {
+			cluster := clusterNames[index]
+			name := strings.Replace(strings.ToLower(cluster), " ", "", -1)
+			input = strings.Replace(strings.ToLower(input), " ", "", -1)
+			return strings.Contains(name, input)
+		}
+
+		p := promptui.Select{
+			Label:     "Select cluster",
+			Items:     clusterNames,
+			Searcher:  searcher,
+			Size:      10,
+			CursorPos: pos,
+		}
+
+		_, selected, err := p.Run()
+		if err != nil {
+			os.Exit(0)
+		}
+
+		// TODO copy pasta
+		if err := cfg.SetCurrentCluster(selected); err != nil {
+			fmt.Printf("Cluster with selected %v not found\n", selected)
+		}
+	},
 }
 
 var configAddClusterCmd = &cobra.Command{

--- a/cmd/kaf/config.go
+++ b/cmd/kaf/config.go
@@ -25,6 +25,7 @@ func init() {
 	configCmd.AddCommand(configAddClusterCmd)
 	configCmd.AddCommand(configRemoveClusterCmd)
 	configCmd.AddCommand(configSelectCluster)
+	rootCmd.AddCommand(lsCommand)
 	configCmd.AddCommand(configCurrentContext)
 	configCmd.AddCommand(configAddEventhub)
 	rootCmd.AddCommand(configCmd)
@@ -116,41 +117,52 @@ var configAddEventhub = &cobra.Command{
 	},
 }
 
+var configSelectClusterRunFunc = func(cmd *cobra.Command, args []string) {
+	var clusterNames []string
+	var pos = 0
+	for k, cluster := range cfg.Clusters {
+		clusterNames = append(clusterNames, cluster.Name)
+		if cluster.Name == cfg.CurrentCluster {
+			pos = k
+		}
+	}
+
+	searcher := func(input string, index int) bool {
+		cluster := clusterNames[index]
+		name := strings.Replace(strings.ToLower(cluster), " ", "", -1)
+		input = strings.Replace(strings.ToLower(input), " ", "", -1)
+		return strings.Contains(name, input)
+	}
+
+	p := promptui.Select{
+		Label:     "Select cluster",
+		Items:     clusterNames,
+		Searcher:  searcher,
+		Size:      10,
+		CursorPos: pos,
+	}
+
+	_, selected, err := p.Run()
+	if err != nil {
+		os.Exit(0)
+	}
+
+	// TODO copy pasta
+	if err := cfg.SetCurrentCluster(selected); err != nil {
+		fmt.Printf("Cluster with selected %v not found\n", selected)
+	}
+}
+
 var configSelectCluster = &cobra.Command{
 	Use:   "select-cluster",
 	Short: "Interactively select a cluster",
-	Run: func(cmd *cobra.Command, args []string) {
-		var clusterNames []string
-		for _, cluster := range cfg.Clusters {
-			clusterNames = append(clusterNames, cluster.Name)
-		}
+	Run:   configSelectClusterRunFunc,
+}
 
-		searcher := func(input string, index int) bool {
-			cluster := clusterNames[index]
-			name := strings.Replace(strings.ToLower(cluster), " ", "", -1)
-			input = strings.Replace(strings.ToLower(input), " ", "", -1)
-			return strings.Contains(name, input)
-		}
-
-		p := promptui.Select{
-			Label:    "Select cluster",
-			Items:    clusterNames,
-			Searcher: searcher,
-			Size:     10,
-		}
-
-		_, selected, err := p.Run()
-		if err != nil {
-			os.Exit(0)
-		}
-
-		// How to have selection on currently selected cluster?
-
-		// TODO copy pasta
-		if err := cfg.SetCurrentCluster(selected); err != nil {
-			fmt.Printf("Cluster with selected %v not found\n", selected)
-		}
-	},
+var lsCommand = &cobra.Command{
+	Use:   "ls",
+	Short: "Interactively select a cluster",
+	Run:   configSelectClusterRunFunc,
 }
 
 var configAddClusterCmd = &cobra.Command{


### PR DESCRIPTION
It was helpful to interact with Kafka using kaf recent days though, some inconveniences appered when deeply using. Supporting highlight current selection as with shortter command will be great benifit to our team,which was Inspired by [nrm ls command](https://github.com/Pana/nrm#example).

Hope to be adopted！