### PR TITLE
Support SASL mechanisms with SASL_PLAINTEXT

### DIFF
--- a/cmd/kaf/kaf.go
+++ b/cmd/kaf/kaf.go
@@ -99,6 +99,8 @@ func getConfig() (saramaConfig *sarama.Config) {
 		} else {
 			saramaConfig.Net.TLS.Config = &tls.Config{InsecureSkipVerify: false}
 		}
+	}
+	if cluster.SecurityProtocol == "SASL_SSL" || cluster.SecurityProtocol == "SASL_PLAINTEXT" {
 		if cluster.SASL.Mechanism == "SCRAM-SHA-512" {
 			saramaConfig.Net.SASL.SCRAMClientGeneratorFunc = func() sarama.SCRAMClient { return &XDGSCRAMClient{HashGeneratorFcn: SHA512} }
 			saramaConfig.Net.SASL.Mechanism = sarama.SASLMechanism(sarama.SASLTypeSCRAMSHA512)


### PR DESCRIPTION
Allow using `SASL` mechanisms other than `PLAIN` with `SASL_PLAINTEXT` security protocol.
This fixes https://github.com/birdayz/kaf/issues/212