### PR TITLE
feat: Allow SASL handshake version to be influenced from config

### DIFF
--- a/cmd/kaf/kaf.go
+++ b/cmd/kaf/kaf.go
@@ -40,6 +40,7 @@ func getConfig() (saramaConfig *sarama.Config) {
 			saramaConfig.Net.SASL.User = cluster.SASL.Username
 			saramaConfig.Net.SASL.Password = cluster.SASL.Password
 		}
+		saramaConfig.Net.SASL.Version = cluster.SASL.Version
 	}
 	if cluster.TLS != nil && cluster.SecurityProtocol != "SASL_SSL" {
 		saramaConfig.Net.TLS.Enable = true

--- a/examples/sasl_v1_handshake.yaml
+++ b/examples/sasl_v1_handshake.yaml
@@ -1,0 +1,9 @@
+clusters:
+- name: test
+  brokers:
+  - localhost:9092
+  SASL:
+    mechanism: PLAIN
+    username: admin
+    password: mypasswordisnotsosimple
+    version: 1

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -17,6 +17,7 @@ type SASL struct {
 	ClientSecret string `yaml:"clientSecret"`
 	TokenURL     string `yaml:"tokenURL"`
 	Token        string `yaml:"token"`
+	Version      int16  `yaml:"version"`
 }
 
 type TLS struct {


### PR DESCRIPTION
why: current kaf uses the older SASL handshake v0, where the SASL payload is sent unframed down the wire.  v1 uses the dedicated SASL Kafka RPCs.  This feature allows the user to opt for the v1.  The default remains as v0.