### PR TITLE
Simple Dockerfile for kaf.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM golang:1.18 as BuildStage
+
+# Set destination for COPY
+WORKDIR /app
+
+# Download Go modules
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . ./
+
+# Build
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags "-w -s" -o /kaf ./cmd/kaf 
+
+FROM scratch
+
+WORKDIR /
+
+COPY --from=BuildStage /kaf /bin/kaf
+
+USER 1001
+
+# Run
+CMD ["/bin/kaf"]

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,10 @@
+DOCKER_CMD ?= docker
+DOCKER_REGISTRY ?= docker.io
+DOCKER_ORG ?= $(USER)
+DOCKER_NAME ?= kaf
+DOCKER_TAG ?= latest
+BUILD_TAG ?= latest
+
 build:
 	go build -ldflags "-w -s" ./cmd/kaf
 install:
@@ -6,3 +13,5 @@ release:
 	goreleaser --rm-dist
 run-kafka:
 	docker-compose up -d
+docker-build:
+	${DOCKER_CMD} build -t ${DOCKER_REGISTRY}/${DOCKER_ORG}/${DOCKER_NAME}:${DOCKER_TAG} .


### PR DESCRIPTION
#289 I would value the ability to easily run `kaf` from a container.  My use-case is operating with kafka clusters that are running within Kubernetes.  The first step towards that is the ability to generate a container image from the source tree.

