### PR TITLE
Allow specifying scopes in oauth config

### DIFF
--- a/cmd/kaf/oauth.go
+++ b/cmd/kaf/oauth.go
@@ -55,6 +55,7 @@ func newTokenProvider() *tokenProvider {
 					ClientID:     cluster.SASL.ClientID,
 					ClientSecret: cluster.SASL.ClientSecret,
 					TokenURL:     cluster.SASL.TokenURL,
+					Scopes:       cluster.SASL.Scopes,
 				},
 				staticToken: false,
 			}

--- a/examples/sasl_ssl_oauth.yaml
+++ b/examples/sasl_ssl_oauth.yaml
@@ -7,6 +7,9 @@ clusters:
     clientID: my_client_oauth
     clientSecret: my_secret_oauth
     tokenURL: https//some.token.endpoint.com/token
+    scopes:
+      - scope1
+      - scope2
   TLS: 
     insecure: true
   security-protocol: SASL_SSL

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -10,14 +10,15 @@ import (
 )
 
 type SASL struct {
-	Mechanism    string `yaml:"mechanism"`
-	Username     string `yaml:"username"`
-	Password     string `yaml:"password"`
-	ClientID     string `yaml:"clientID"`
-	ClientSecret string `yaml:"clientSecret"`
-	TokenURL     string `yaml:"tokenURL"`
-	Token        string `yaml:"token"`
-	Version      int16  `yaml:"version"`
+	Mechanism    string   `yaml:"mechanism"`
+	Username     string   `yaml:"username"`
+	Password     string   `yaml:"password"`
+	ClientID     string   `yaml:"clientID"`
+	ClientSecret string   `yaml:"clientSecret"`
+	TokenURL     string   `yaml:"tokenURL"`
+	Scopes       []string `yaml:"scopes"`
+	Token        string   `yaml:"token"`
+	Version      int16    `yaml:"version"`
 }
 
 type TLS struct {


### PR DESCRIPTION
Although `scopes` is optional, some OIDC providers refuse to authenticate if scopes are not configured properly. 