### PR TITLE
Use ENTRYPOINT instead of CMD in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,4 @@ COPY --from=BuildStage /kaf /bin/kaf
 USER 1001
 
 # Run
-CMD ["/bin/kaf"]
+ENTRYPOINT ["/bin/kaf"]


### PR DESCRIPTION
Related issue #289 and PR #297 for Dockerfile. Thanks @k-wall for the Dockerfile!

This PR changes to use ENTRYPOINT instead of CMD in Dockerfile so that we can run, for example,

> docker run --rm -it kaf nodes

instead of

> docker run --rm -it kaf kaf nodes

This makes run ad-hoc commands easier.

Besides, we build image from scratch, so we have no other commands to run from the image.