### PR TITLE
fix: Corrupted lines in produce cmd with 'line' mode

### DIFF
--- a/cmd/kaf/produce.go
+++ b/cmd/kaf/produce.go
@@ -69,7 +69,7 @@ func readLines(reader io.Reader, out chan []byte) {
 	}
 
 	for scanner.Scan() {
-		out <- scanner.Bytes()
+		out <- bytes.Clone(scanner.Bytes())
 	}
 	close(out)
 


### PR DESCRIPTION
`scanner.Bytes()` returns internal buffer which is reused. That results in corrupted messages as message value (internal buffer) is modified by `scanner` while being sent to kafka.