### PR TITLE
remove unnecessary nil check

### DIFF
--- a/cmd/kaf/consume.go
+++ b/cmd/kaf/consume.go
@@ -351,7 +351,7 @@ func formatMessage(msg *sarama.ConsumerMessage, rawMessage []byte, keyToDisplay 
 
 		}
 
-		if msg.Key != nil && len(msg.Key) > 0 {
+		if len(msg.Key) > 0 {
 			fmt.Fprintf(w, "Key:\t%v\n", string(keyToDisplay))
 		}
 		fmt.Fprintf(w, "Partition:\t%v\nOffset:\t%v\nTimestamp:\t%v\n", msg.Partition, msg.Offset, msg.Timestamp)


### PR DESCRIPTION
[cmd/kaf/consume.go](https://github.com/birdayz/kaf/blob/50d01e97d7156d08cf89c40cc357f03494bf66fd/cmd/kaf/consume.go#L354): remove unnecessay nil check.

```
var slice []byte
if slice != nil && len(slice) > 0 {}
// is the same as
if len(slice) > 0 {}
```
because `len(slice)` where slice == nil is always equal to 0,

`staticcheck` will highlight this optimization with the following message:
```
cmd/kaf/consume.go:354:6: should omit nil check; len() for []byte is defined as zero (S1009)
```

for reference: [staticcheck S1009](https://staticcheck.dev/docs/checks#S1009)