### PR TITLE
Update go image, allow dependabot to update docker file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,8 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+  - package-ecosystem: "docker"
+    directories:
+      - "/"
+    schedule:
+      interval: "daily"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22 as BuildStage
+FROM golang:1.24.2@sha256:d9db32125db0c3a680cfb7a1afcaefb89c898a075ec148fdc2f0f646cc2ed509 AS buildstage
 
 # Set destination for COPY
 WORKDIR /app
@@ -15,7 +15,7 @@ FROM scratch
 
 WORKDIR /
 
-COPY --from=BuildStage /kaf /bin/kaf
+COPY --from=buildstage /kaf /bin/kaf
 
 USER 1001
 


### PR DESCRIPTION
The current go build image was EOF once go 1.24 was released.

Update dependabot so it can automatically help keep your go image up to date