### PR TITLE
Add GitHub Action to Build and Publish Docker Image on Release

### DIFF
--- a/.github/workflows/dockerCi.yml
+++ b/.github/workflows/dockerCi.yml
@@ -1,0 +1,58 @@
+name: Docker Image CI
+
+on: [workflow_dispatch]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Create temporary Dockerfile
+        run: |
+          cat <<'EOF' > Dockerfile
+          FROM alpine:3.18
+
+          RUN apk add --no-cache curl ca-certificates
+
+          ENV KAF_REPO=birdayz/kaf
+
+          RUN KAF_LATEST_URL=$(curl -s https://api.github.com/repos/${KAF_REPO}/releases/latest \
+              | grep "browser_download_url.*kaf-linux-amd64" \
+              | cut -d '"' -f 4) \
+            && curl -L "$KAF_LATEST_URL" -o /usr/local/bin/kaf \
+            && chmod +x /usr/local/bin/kaf
+
+          ENTRYPOINT ["/usr/local/bin/kaf"]
+          EOF
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/dockerCi.yml
+++ b/.github/workflows/dockerCi.yml
@@ -1,58 +1,93 @@
-name: Docker Image CI
+name: Build and Push Docker Image
 
-on: [workflow_dispatch]
+on:
+  release:
+    types: [published]
+  workflow_dispatch:  # 👈 Allow manual execution
 
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  build-and-push-image:
+  build-and-push:
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
 
     steps:
-      - name: Checkout repository
+      - name: Checkout repo (optional)
         uses: actions/checkout@v3
 
-      - name: Create temporary Dockerfile
+      - name: Set KAF version
+        id: vars
         run: |
-          cat <<'EOF' > Dockerfile
-          FROM alpine:3.18
+          if [ "${{ github.event_name }}" == "release" ]; then
+            echo "version=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
+          else
+            # fallback to latest release from upstream
+            latest=$(curl -s https://api.github.com/repos/birdayz/kaf/releases/latest | jq -r .tag_name)
+            echo "version=$latest" >> $GITHUB_OUTPUT
+          fi
 
-          RUN apk add --no-cache curl ca-certificates
+      - name: Generate Dockerfile dynamically
+        run: |
+          cat <<EOF > Dockerfile
+          FROM registry.access.redhat.com/ubi8/ubi-minimal
 
-          ENV KAF_REPO=birdayz/kaf
+          # Install essential tools, including busybox, jq, yq, and other useful CLI packages
+          RUN microdnf install -y \
+                curl \
+                bash \
+                ca-certificates \
+                shadow-utils \
+                passwd \
+                findutils \
+                iproute \
+                iputils \
+                procps-ng \
+                jq \
+                tar \
+                zip \
+                unzip \
+              && microdnf clean all
 
-          RUN KAF_LATEST_URL=$(curl -s https://api.github.com/repos/${KAF_REPO}/releases/latest \
-              | grep "browser_download_url.*kaf-linux-amd64" \
-              | cut -d '"' -f 4) \
-            && curl -L "$KAF_LATEST_URL" -o /usr/local/bin/kaf \
-            && chmod +x /usr/local/bin/kaf
+          # Install yq (Go-based binary from GitHub)
+          RUN curl -sL https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 \
+              -o /usr/local/bin/yq && chmod +x /usr/local/bin/yq
 
-          ENTRYPOINT ["/usr/local/bin/kaf"]
+          RUN useradd -m admin && \
+              echo 'admin:admin' | chpasswd
+
+          ENV KAF_VERSION=${{ steps.vars.outputs.version }}
+
+          RUN curl https://raw.githubusercontent.com/birdayz/kaf/master/godownloader.sh | BINDIR=/usr/local/bin bash
+
+          USER admin
           EOF
 
-      - name: Log in to the Container registry
+      - name: Log in to GitHub Container Registry
         uses: docker/login-action@v2
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata (tags, labels) for Docker
+      - name: Extract Docker metadata
         id: meta
         uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=${{ steps.vars.outputs.version }}
+            type=raw,value=latest
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v4
         with:
           context: .
-          file: ./Dockerfile
+          file: Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
This PR introduces a GitHub Actions workflow named `Build and Push Docker Image` that:

- Automatically builds and publishes a Docker image to GitHub Container Registry (GHCR)
- Triggers on new releases (`release: published`) and also supports manual execution (`workflow_dispatch`)
- Dynamically generates a Dockerfile based on Red Hat UBI 8 Minimal
- Downloads the official `kaf` binary using the upstream godownloader script
- Installs useful CLI tools such as jq, yq, tar, zip, and bash
- Runs the image as a non-root `admin` user to align with container security best practices

The resulting image will be published under:
`ghcr.io/<user>/<repo>:<version>` and `:latest`
