### PR TITLE
Add support for pipes and consume --header flag to filter out messages by defined headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,28 @@ Write message into given topic from stdin
 
 `echo test | kaf produce mqtt.messages.incoming`
 
+```
+echo {"data":1} | kaf produce mqtt.messages.incoming --key 1 --header h1:hv1
+> Sent record to partition 0 at offset 0.
+
+kaf consume mqtt.messages.incoming --output json-each-row
+> {"topic":"mqtt.messages.incoming","partition":0,"offset":0,"timestamp":"2025-07-04T12:53:46.841+02:00","headers":[{"key":"h1","value":"hv1"}],"key":"1","payload":"{data:1}"}
+
+
+echo '{"topic":"mqtt.messages.incoming","partition":0,"offset":0,"timestamp":"2025-07-04T12:53:46.841+02:00","headers":[{"key":"h1","value":"hv1"}],"key":"1","payload":"{data:1}"}' | kaf produce mqtt.messages.incoming --input json-each-row
+
+kaf consume mqtt.messages.incoming --output json-each-row
+> {"topic":"mqtt.messages.incoming","partition":0,"offset":1,"timestamp":"2025-07-04T13:05:57.9+02:00","headers":[{"key":"h1","value":"hv1"}],"key":"1","payload":"{data:1}"}
+```
+
+Pipe from one topic to another
+`kaf consume topic-a --output json-each-row -f | kaf produce topic-b --input json-each-row`
+
+Important: kaf produce will overwrite key, partition and all the headers and of input messages if provided
+
+Consume messages with filtering by header
+`kaf consume mqtt.messages.incoming --header h1:hv1`
+
 ### Offset Reset
 
 Set offset for consumer group _dispatcher_ consuming from topic _mqtt.messages.incoming_ to latest for all partitions
@@ -122,4 +144,3 @@ Powershell
 - 10x lower P99 latencies, 6x faster transactions
 - Zero data loss by default
 ### [Zerodha](https://zerodha.tech)
-

--- a/cmd/kaf/consume.go
+++ b/cmd/kaf/consume.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"strings"
 	"sync"
 	"text/tabwriter"
 
@@ -14,7 +15,7 @@ import (
 	"github.com/birdayz/kaf/pkg/avro"
 	"github.com/birdayz/kaf/pkg/proto"
 	"github.com/golang/protobuf/jsonpb"
-	prettyjson "github.com/hokaccha/go-prettyjson"
+	"github.com/hokaccha/go-prettyjson"
 	"github.com/spf13/cobra"
 	"github.com/vmihailenco/msgpack/v5"
 )
@@ -39,13 +40,16 @@ var (
 	limitMessagesFlag int64
 
 	reg *proto.DescriptorRegistry
+
+	headerFilterFlag []string
+	headerFilter     = make(map[string]string)
 )
 
 func init() {
 	rootCmd.AddCommand(consumeCmd)
 	consumeCmd.Flags().StringVar(&offsetFlag, "offset", "oldest", "Offset to start consuming. Possible values: oldest, newest, or integer.")
 	consumeCmd.Flags().BoolVar(&raw, "raw", false, "Print raw output of messages, without key or prettified JSON")
-	consumeCmd.Flags().Var(&outputFormat, "output", "Set output format messages: default, raw (without key or prettified JSON), json")
+	consumeCmd.Flags().Var(&outputFormat, "output", "Set output format messages: default, raw (without key or prettified JSON), json, json-each-row")
 	consumeCmd.Flags().BoolVarP(&follow, "follow", "f", false, "Continue to consume messages until program execution is interrupted/terminated")
 	consumeCmd.Flags().Int32VarP(&tail, "tail", "n", 0, "Print last n messages per partition")
 	consumeCmd.Flags().StringSliceVar(&protoFiles, "proto-include", []string{}, "Path to proto files")
@@ -57,6 +61,7 @@ func init() {
 	consumeCmd.Flags().Int64VarP(&limitMessagesFlag, "limit-messages", "l", 0, "Limit messages per partition")
 	consumeCmd.Flags().StringVarP(&groupFlag, "group", "g", "", "Consumer Group to use for consume")
 	consumeCmd.Flags().BoolVar(&groupCommitFlag, "commit", false, "Commit Group offset after receiving messages. Works only if consuming as Consumer Group")
+	consumeCmd.Flags().StringSliceVar(&headerFilterFlag, "header", []string{}, "Filter messages by header. Format: key:value. Multiple filters can be specified")
 
 	if err := consumeCmd.RegisterFlagCompletionFunc("output", completeOutputFormat); err != nil {
 		errorExit("Failed to register flag completion: %v", err)
@@ -123,6 +128,14 @@ var consumeCmd = &cobra.Command{
 				errorExit("Could not parse '%s' to int64: %w", offsetFlag, err)
 			}
 			offset = o
+		}
+
+		for _, f := range headerFilterFlag {
+			parts := strings.SplitN(f, ":", 2)
+			if len(parts) != 2 {
+				errorExit("Invalid header filter format: %s. Expected format: key:value", f)
+			}
+			headerFilter[parts[0]] = parts[1]
 		}
 
 		if groupFlag != "" {
@@ -239,7 +252,27 @@ func withoutConsumerGroup(ctx context.Context, client sarama.Client, topic strin
 	wg.Wait()
 }
 
+func checkHeaders(headers []*sarama.RecordHeader, filter map[string]string) bool {
+	if len(filter) == 0 {
+		return true
+	}
+
+	matchCount := 0
+	for _, h := range headers {
+		hdrStr := parseHeader(h.Value)
+		if val, ok := filter[string(h.Key)]; ok && hdrStr == val {
+			matchCount++
+		}
+	}
+
+	return len(headers) > 0 && matchCount >= len(headers)
+}
+
 func handleMessage(msg *sarama.ConsumerMessage, mu *sync.Mutex) {
+	if !checkHeaders(msg.Headers, headerFilter) {
+		return
+	}
+
 	var stderr bytes.Buffer
 
 	var dataToDisplay []byte
@@ -292,6 +325,22 @@ func handleMessage(msg *sarama.ConsumerMessage, mu *sync.Mutex) {
 	mu.Unlock()
 }
 
+func parseHeader(hdrBytes []byte) (hdrStr string) {
+	// Try to detect azure eventhub-specific encoding
+	if len(hdrBytes) > 0 {
+		switch hdrBytes[0] {
+		case 161:
+			hdrStr = string(hdrBytes[2 : 2+hdrBytes[1]])
+		case 131:
+			hdrStr = strconv.FormatUint(binary.BigEndian.Uint64(hdrBytes[1:9]), 10)
+		default:
+			hdrStr = string(hdrBytes)
+		}
+	}
+
+	return hdrStr
+}
+
 func formatMessage(msg *sarama.ConsumerMessage, rawMessage []byte, keyToDisplay []byte, stderr *bytes.Buffer) []byte {
 	switch outputFormat {
 	case OutputFormatRaw:
@@ -309,6 +358,29 @@ func formatMessage(msg *sarama.ConsumerMessage, rawMessage []byte, keyToDisplay 
 
 		jsonMessage["key"] = formatJSON(keyToDisplay)
 		jsonMessage["payload"] = formatJSON(rawMessage)
+
+		jsonToDisplay, err := json.Marshal(jsonMessage)
+		if err != nil {
+			fmt.Fprintf(stderr, "could not decode JSON data: %v", err)
+		}
+
+		return jsonToDisplay
+	case OutputFormatJSONEachRow:
+		jsonMessage := JSONEachRowMessage{}
+		jsonMessage.Topic = msg.Topic
+		jsonMessage.Partition = msg.Partition
+		jsonMessage.Offset = msg.Offset
+		jsonMessage.Timestamp = msg.Timestamp
+		jsonMessage.Headers = make([]MessageHeader, len(msg.Headers))
+		for i, hdr := range msg.Headers {
+			hdrStr := parseHeader(hdr.Value)
+			jsonMessage.Headers[i] = MessageHeader{
+				Key:   string(hdr.Key),
+				Value: hdrStr,
+			}
+		}
+		jsonMessage.Key = string(keyToDisplay)
+		jsonMessage.Payload = string(rawMessage)
 
 		jsonToDisplay, err := json.Marshal(jsonMessage)
 		if err != nil {
@@ -334,21 +406,8 @@ func formatMessage(msg *sarama.ConsumerMessage, rawMessage []byte, keyToDisplay 
 		}
 
 		for _, hdr := range msg.Headers {
-			var hdrValue string
-			// Try to detect azure eventhub-specific encoding
-			if len(hdr.Value) > 0 {
-				switch hdr.Value[0] {
-				case 161:
-					hdrValue = string(hdr.Value[2 : 2+hdr.Value[1]])
-				case 131:
-					hdrValue = strconv.FormatUint(binary.BigEndian.Uint64(hdr.Value[1:9]), 10)
-				default:
-					hdrValue = string(hdr.Value)
-				}
-			}
-
-			fmt.Fprintf(w, "\tKey: %v\tValue: %v\n", string(hdr.Key), hdrValue)
-
+			hdrStr := parseHeader(hdr.Value)
+			fmt.Fprintf(w, "\tKey: %v\tValue: %v\n", string(hdr.Key), hdrStr)
 		}
 
 		if len(msg.Key) > 0 {
@@ -426,9 +485,10 @@ func isJSON(data []byte) bool {
 type OutputFormat string
 
 const (
-	OutputFormatDefault OutputFormat = "default"
-	OutputFormatRaw     OutputFormat = "raw"
-	OutputFormatJSON    OutputFormat = "json"
+	OutputFormatDefault     OutputFormat = "default"
+	OutputFormatRaw         OutputFormat = "raw"
+	OutputFormatJSON        OutputFormat = "json"
+	OutputFormatJSONEachRow OutputFormat = "json-each-row"
 )
 
 func (e *OutputFormat) String() string {
@@ -437,11 +497,11 @@ func (e *OutputFormat) String() string {
 
 func (e *OutputFormat) Set(v string) error {
 	switch v {
-	case "default", "raw", "json":
+	case "default", "raw", "json", "json-each-row":
 		*e = OutputFormat(v)
 		return nil
 	default:
-		return fmt.Errorf("must be one of: default, raw, json")
+		return fmt.Errorf("must be one of: default, raw, json, json-each-row")
 	}
 }
 
@@ -450,5 +510,5 @@ func (e *OutputFormat) Type() string {
 }
 
 func completeOutputFormat(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	return []string{"default", "raw", "json"}, cobra.ShellCompDirectiveNoFileComp
+	return []string{"default", "raw", "json", "json-each-row"}, cobra.ShellCompDirectiveNoFileComp
 }

--- a/cmd/kaf/consume_test.go
+++ b/cmd/kaf/consume_test.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/IBM/sarama"
+)
+
+func TestCheckHeaders(t *testing.T) {
+	tests := []struct {
+		name         string
+		headerFilter map[string]string
+		headers      []*sarama.RecordHeader
+		want         bool
+	}{
+		{
+			name:         "no filter",
+			headerFilter: map[string]string{},
+			headers: []*sarama.RecordHeader{
+				{Key: []byte("a"), Value: []byte("b")},
+			},
+			want: true,
+		},
+		{
+			name: "matching header",
+			headerFilter: map[string]string{
+				"a": "b",
+			},
+			headers: []*sarama.RecordHeader{
+				{Key: []byte("a"), Value: []byte("b")},
+			},
+			want: true,
+		},
+		{
+			name: "non-matching header value",
+			headerFilter: map[string]string{
+				"a": "c",
+			},
+			headers: []*sarama.RecordHeader{
+				{Key: []byte("a"), Value: []byte("b")},
+			},
+			want: false,
+		},
+		{
+			name: "non-matching header key",
+			headerFilter: map[string]string{
+				"c": "b",
+			},
+			headers: []*sarama.RecordHeader{
+				{Key: []byte("a"), Value: []byte("b")},
+			},
+			want: false,
+		},
+		{
+			name: "multiple filters match",
+			headerFilter: map[string]string{
+				"a": "b",
+				"c": "d",
+			},
+			headers: []*sarama.RecordHeader{
+				{Key: []byte("a"), Value: []byte("b")},
+				{Key: []byte("c"), Value: []byte("d")},
+			},
+			want: true,
+		},
+		{
+			name: "multiple filters one mismatch",
+			headerFilter: map[string]string{
+				"a": "b",
+				"c": "e",
+			},
+			headers: []*sarama.RecordHeader{
+				{Key: []byte("a"), Value: []byte("b")},
+				{Key: []byte("c"), Value: []byte("d")},
+			},
+			want: false,
+		},
+		{
+			name:         "no headers with filter",
+			headerFilter: map[string]string{"a": "b"},
+			headers:      []*sarama.RecordHeader{},
+			want:         false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := checkHeaders(tt.headers, tt.headerFilter); got != tt.want {
+				t.Errorf("checkHeaders() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/kaf/message.go
+++ b/cmd/kaf/message.go
@@ -1,0 +1,17 @@
+package main
+
+import "time"
+
+type MessageHeader struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+type JSONEachRowMessage struct {
+	Topic     string          `json:"topic"`
+	Partition int32           `json:"partition"`
+	Offset    int64           `json:"offset"`
+	Timestamp time.Time       `json:"timestamp"`
+	Headers   []MessageHeader `json:"headers"`
+	Key       string          `json:"key"`
+	Payload   string          `json:"payload"`
+}


### PR DESCRIPTION
**PR adds support for pipes.** 
Output of kaf consume can be used as input for kaf produce. 
This is possible by adding `json-each-row` input/output format.

```
echo {"data":1} | kaf produce mqtt.messages.incoming --key 1 --header h1:hv1
> Sent record to partition 0 at offset 0.

kaf consume mqtt.messages.incoming --output json-each-row
> {"topic":"mqtt.messages.incoming","partition":0,"offset":0,"timestamp":"2025-07-04T12:53:46.841+02:00","headers":[{"key":"h1","value":"hv1"}],"key":"1","payload":"{data:1}"}


echo '{"topic":"mqtt.messages.incoming","partition":0,"offset":0,"timestamp":"2025-07-04T12:53:46.841+02:00","headers":[{"key":"h1","value":"hv1"}],"key":"1","payload":"{data:1}"}' | kaf produce mqtt.messages.incoming --input json-each-row

kaf consume mqtt.messages.incoming --output json-each-row
> {"topic":"mqtt.messages.incoming","partition":0,"offset":1,"timestamp":"2025-07-04T13:05:57.9+02:00","headers":[{"key":"h1","value":"hv1"}],"key":"1","payload":"{data:1}"}
```

Pipe from one topic to another
`kaf consume topic-a --output json-each-row -f | kaf produce topic-b --input json-each-row`

_Important: kaf produce will overwrite key, partition and all the headers of input messages if provided_
May solve https://github.com/birdayz/kaf/issues/373, related to https://github.com/birdayz/kaf/issues/108

**PR adds consume  --header flag to filter out messages by defined headers.**

Consume messages with filtering by header
`kaf consume mqtt.messages.incoming --header h1:hv1`