### PR TITLE
Add support for configuring proto types in config

### DIFF
--- a/cmd/kaf/consume.go
+++ b/cmd/kaf/consume.go
@@ -98,7 +98,7 @@ var consumeCmd = &cobra.Command{
 	Short:             "Consume messages",
 	Args:              cobra.ExactArgs(1),
 	ValidArgsFunction: validTopicArgs,
-	PreRun:            setupProtoDescriptorRegistry,
+	PreRun:            consumePreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		var offset int64
 		cfg := getConfig()
@@ -132,6 +132,19 @@ var consumeCmd = &cobra.Command{
 		}
 
 	},
+}
+
+func consumePreRun(cmd *cobra.Command, args []string) {
+	if protoType == "" {
+		for _, topic := range cfg.Topics {
+			if topic.Name == args[0] {
+				protoType = topic.ProtoType
+				protoFiles = topic.ProtoPaths
+				break
+			}
+		}
+	}
+	setupProtoDescriptorRegistry(cmd, args)
 }
 
 type g struct{}

--- a/cmd/kaf/produce.go
+++ b/cmd/kaf/produce.go
@@ -91,7 +91,7 @@ var produceCmd = &cobra.Command{
 	Short:             "Produce record. Reads data from stdin.",
 	Args:              cobra.ExactArgs(1),
 	ValidArgsFunction: validTopicArgs,
-	PreRun:            setupProtoDescriptorRegistry,
+	PreRun:            producePreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		cfg := getConfig()
 		switch partitionerFlag {
@@ -256,4 +256,17 @@ var produceCmd = &cobra.Command{
 			}
 		}
 	},
+}
+
+func producePreRun(cmd *cobra.Command, args []string) {
+	if protoType == "" {
+		for _, topic := range cfg.Topics {
+			if topic.Name == args[0] {
+				protoType = topic.ProtoType
+				protoFiles = topic.ProtoPaths
+				break
+			}
+		}
+	}
+	setupProtoDescriptorRegistry(cmd, args)
 }

--- a/examples/proto-types.yaml
+++ b/examples/proto-types.yaml
@@ -1,0 +1,17 @@
+clusters:
+  - name: local
+    brokers:
+      - localhost:9092
+    SASL: null
+    TLS: null
+    security-protocol: ""
+    version: "1.0.0"
+topics:
+  - name: topic1
+    proto-type: local.ProtoType1
+    proto-paths:
+      - /path_to_proto_files/proto_storage
+  - name: topic2
+    proto-type: local.ProtoType2
+    proto-paths:
+      - /path_to_proto_files/proto_storage

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -44,10 +44,17 @@ type Cluster struct {
 	SchemaRegistryCredentials *SchemaRegistryCredentials `yaml:"schema-registry-credentials"`
 }
 
+type Topic struct {
+	Name       string   `yaml:"name"`
+	ProtoType  string   `yaml:"proto-type"`
+	ProtoPaths []string `yaml:"proto-paths"`
+}
+
 type Config struct {
 	CurrentCluster  string `yaml:"current-cluster"`
 	ClusterOverride string
 	Clusters        []*Cluster `yaml:"clusters"`
+	Topics          []Topic    `yaml:"topics"`
 }
 
 func (c *Config) SetCurrentCluster(name string) error {


### PR DESCRIPTION
Added support for configuring proto types in `~/.kaf/config`. It allows to simply use 
```bash
kaf consume <topic>
```
instead of 
```bash
kaf consume <topic> --proto-type <proto_type> --proto-include <path>
```