### PR TITLE
feat: support aws profile

### DIFF
--- a/cmd/kaf/oauth.go
+++ b/cmd/kaf/oauth.go
@@ -47,11 +47,20 @@ func newTokenProvider() *tokenProvider {
 
 		// token either from tokenURL, static or AWS API
 		if cluster.SASL.Mechanism == "AWS_MSK_IAM" {
-			cfg, err := aws_config.LoadDefaultConfig(ctx)
+			var awsOpts []func(*aws_config.LoadOptions) error
+			if cluster.SASL.AWSProfile != "" {
+				awsOpts = append(awsOpts, aws_config.WithSharedConfigProfile(cluster.SASL.AWSProfile))
+			}
+			cfg, err := aws_config.LoadDefaultConfig(ctx, awsOpts...)
 			if err != nil {
 				errorExit("Could not load AWS config: " + err.Error())
 			}
-			token, _, err := aws_signer.GenerateAuthToken(ctx, cfg.Region)
+			var token string
+			if cluster.SASL.AWSProfile != "" {
+				token, _, err = aws_signer.GenerateAuthTokenFromProfile(ctx, cfg.Region, cluster.SASL.AWSProfile)
+			} else {
+				token, _, err = aws_signer.GenerateAuthToken(ctx, cfg.Region)
+			}
 			if err != nil {
 				errorExit("Could not generate auth token: " + err.Error())
 			}

--- a/examples/aws_msk_iam.yaml
+++ b/examples/aws_msk_iam.yaml
@@ -4,6 +4,7 @@ clusters:
       - localhost:9092
     SASL:
       mechanism: AWS_MSK_IAM
+      # awsProfile: my-profile  # optional: use a named AWS profile instead of env vars or the default profile
     TLS: null
     security-protocol: SASL_SSL
 # set the region using the AWS_REGION envvar or saved profiles

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -19,6 +19,7 @@ type SASL struct {
 	Scopes       []string `yaml:"scopes"`
 	Token        string   `yaml:"token"`
 	Version      int16    `yaml:"version"`
+	AWSProfile   string   `yaml:"awsProfile"`
 }
 
 type TLS struct {


### PR DESCRIPTION
Hey

I'd like to use a profile instead of defining static access/secrets or exporting envs in the session whenever I want to use the CLI. 

With a profile, I can use temporary tokens, and once I refresh them, it will continue working. It’s also more similar to kubectl, which kaf was inspired by

Thank you :) @birdayz 